### PR TITLE
Updating the getting started to have the proper URL with api/1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM maven:3-jdk-8-slim as builder
+FROM maven:3.5.3-jdk-8 as builder
 
 ARG OBJECT_URL
 ARG INDEXING_PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM maven:3-jdk-8 as builder
+FROM maven:3-jdk-8-slim as builder
 
 ARG OBJECT_URL
 ARG INDEXING_PORT
@@ -14,8 +14,10 @@ ENV INDEXING_ELASTIC_PORT ${INDEXING_ELASTIC_PORT}
 ENV INDEXING_ELASTIC_PROTOCOL ${INDEXING_ELASTIC_PROTOCOL}
 
 RUN mkdir -p /usr/src/app
-COPY . /usr/src/app
+COPY pom.xml /usr/src/app
 WORKDIR /usr/src/app
+RUN mvn dependency:resolve
+COPY . /usr/src/app
 RUN mvn clean package
 
 # run stage

--- a/src/main/java/gov/cdc/foundation/controller/IndexingController.java
+++ b/src/main/java/gov/cdc/foundation/controller/IndexingController.java
@@ -598,7 +598,7 @@ public class IndexingController {
 
 	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('indexing.'.concat(#configName)) or #config.startsWith('public-')")
 	@RequestMapping(value = "config/{config}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified configuration", notes = "Create or update configuration")
+	@ApiOperation(value = "Create or update values for the specified configuration", notes = "Create or update configuration")
 	@ResponseBody
 	public ResponseEntity<?> upsertConfigWithPut(
 			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
@@ -609,7 +609,7 @@ public class IndexingController {
 
 	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('indexing.'.concat(#configName)) or #configName.startsWith('public-')")
 	@RequestMapping(value = "config/{config}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Create or update rules for the specified configuration", notes = "Create or update configuration")
+	@ApiOperation(value = "Create or update values for the specified configuration", notes = "Create or update configuration")
 	@ResponseBody
 	public ResponseEntity<?> upsertConfig(
 			@ApiIgnore @RequestHeader(value = "Authorization", required = false) String authorizationHeader,

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -96,25 +96,25 @@
     --data "@config.json"</code></pre>
       <p>Next you need to register the index with Elasticsearch:</p>
       <button class="btn" data-clipboard-target="#curl-cmd-pre-2">Copy</button>
-      <pre id="curl-cmd-pre-2"><code>curl -X PUT '<span class='origin'>http://127.0.0.1:8084/</span>index/[CONFIG]'</code></pre>
+      <pre id="curl-cmd-pre-2"><code>curl -X PUT '<span class='origin'>http://127.0.0.1:8084/</span>api/1.0/index/[CONFIG]'</code></pre>
       <p>When everything is configured, you can call the following URL to index an object (by using Swagger or <code>curl</code>):</p>
       <button class="btn" data-clipboard-target="#curl-cmd-1">Copy</button>
       <pre id="curl-cmd-1"><code>curl -X POST \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
-    '<span class='origin'>http://127.0.0.1:8084/</span>index/[CONFIG]/[OBJECT ID]'</code></pre>
+    '<span class='origin'>http://127.0.0.1:8084/</span>api/1.0/index/[CONFIG]/[OBJECT ID]'</code></pre>
       <p>Where the value of <code>[CONFIG]</code> is defined in your config, and the <code>[OBJECT ID]</code> is the object identifier in the database.</p>
       <p>You can double check that your object is properly indexed with the following URL:<p>
       <button class="btn" data-clipboard-target="#curl-cmd-2">Copy</button>
       <pre id="curl-cmd-2"><code>curl -X GET \
     --header 'Accept: application/json' \
-    '<span class='origin'>http://127.0.0.1:8084/</span>get/[CONFIG]/[OBJECT ID]'</code></pre>
+    '<span class='origin'>http://127.0.0.1:8084/</span>api/1.0/get/[CONFIG]/[OBJECT ID]'</code></pre>
       <p>Finally, you can just search for all indexed objects in Elastic:</p>
       <button class="btn" data-clipboard-target="#curl-cmd-3">Copy</button>
       <pre id="curl-cmd-3"><code>curl -X POST \
     --header 'Content-Type: application/json' \
     --header 'Accept: application/json' \
-    '<span class='origin'>http://127.0.0.1:8084/</span>search/[CONFIG]'</code></pre>
+    '<span class='origin'>http://127.0.0.1:8084/</span>api/1.0/search/[CONFIG]'</code></pre>
     </section>
   </div>
   <script>

--- a/src/test/fdns-ms-indexing - IndexingApplication.launch
+++ b/src/test/fdns-ms-indexing - IndexingApplication.launch
@@ -24,12 +24,14 @@
 </mapAttribute>
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_APPEND_TO_FILE" value="true"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.springframework.ide.eclipse.boot.launch.BootMavenClassPathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="gov.cdc.foundation.IndexingApplication"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="fdns-ms-indexing"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.springframework.ide.eclipse.boot.launch.BootMavenSourcePathProvider"/>
 <booleanAttribute key="spring.boot.ansi.console" value="false"/>
 <booleanAttribute key="spring.boot.dash.hidden" value="false"/>
 <booleanAttribute key="spring.boot.debug.enable" value="false"/>
+<booleanAttribute key="spring.boot.fast.startup" value="true"/>
 <booleanAttribute key="spring.boot.jmx.enable" value="true"/>
 <booleanAttribute key="spring.boot.lifecycle.enable" value="true"/>
 <stringAttribute key="spring.boot.lifecycle.termination.timeout" value="15000"/>


### PR DESCRIPTION
This pull request adds the following:

- Fixes a confusing description in the swagger UI that describes rules when it's just a configuration file
- Updates the getting started guide found in `index.html` to have the proper paths for api/1.0 included.