### PR TITLE
Updating documentation for docker hub

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,91 @@
+# FDNS Indexing Microservice
+
+Foundation Services (FDNS) Indexing Microservice is the navigation layer of the data lake.
+
+## Getting Started
+
+To get started with the FDNS Indexing Microservice you can use either `docker stack deploy` or `docker-compose`:
+
+```yaml
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  fdns-ms-object:
+    image: cdcgov/fdns-ms-object
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+      - mongo
+    environment:
+      OBJECT_PORT: 8083
+      OBJECT_MONGO_HOST: mongo
+      OBJECT_MONGO_PORT: 27017
+      OBJECT_FLUENTD_HOST: fluentd
+      OBJECT_FLUENTD_PORT: 24224
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.0
+    ports:
+      - "9200:9200"
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+  fdns-ms-indexing:
+    image: cdcgov/fdns-ms-indexing
+    ports:
+      - "8084:8084"
+    depends_on:
+      - fluentd
+      - elastic
+      - fdns-ms-object
+    environment:
+      INDEXING_PORT: 8084
+      INDEXING_ELASTIC_HOST: elastic
+      INDEXING_ELASTIC_PORT: 9200
+      INDEXING_ELASTIC_PROTOCOL: http
+      INDEXING_FLUENTD_HOST: fluentd
+      INDEXING_FLUENTD_PORT: 24224
+      OBJECT_URL: http://fdns-ms-object:8083
+```
+
+[![Try in PWD](https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/CDCgov/fdns-ms-indexing/master/stack.yml)
+
+## Source Code
+
+Please see [https://github.com/CDCgov/fdns-ms-indexing](https://github.com/CDCgov/fdns-ms-indexing) for the fdns-ms-indexing source repository.
+
+## Public Domain
+
+This repository constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. This repository is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions to this repository will be released under the CC0 dedication.
+
+## License
+
+The repository utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
+
+The container image in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
+
+## Privacy
+
+This repository contains only non-sensitive, publicly available data and information. All material and community participation is covered by the Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
+
+## Records
+
+This repository is not a source of government records, but is a copy to increase collaboration and collaborative potential. All government records will be published through the [CDC web site](http://www.cdc.gov).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 [![Build Status](https://travis-ci.org/CDCgov/fdns-ms-indexing.svg?branch=master)](https://travis-ci.org/CDCgov/fdns-ms-indexing)
 
 # FDNS Indexing Microservice
+
 This repository contains the indexing layer for the Data Lake. The indexing layer is also known as the navigation layer.
 
 ## Running locally
+
 Carefully read the following instructions for information on how to build, run, and test this microservice in your local environment.
 
 ### Before you start
+
 You will need to have the following software installed to run this microservice in your local environment:
 
 - Docker, [Installation guides](https://docs.docker.com/install/)
@@ -17,7 +20,7 @@ You will need to have the following software installed to run this microservice 
 
 First, you'll need to build the image. You can build the image by running the following command:
 
-```
+```sh
 make docker-build
 ```
 
@@ -25,7 +28,7 @@ make docker-build
 
 Once the image has been built, you can run it with the following command:
 
-```
+```sh
 make docker-run
 ```
 
@@ -45,14 +48,15 @@ To access the Swagger documentation, open the following URL in your browser:
 
 You can configure the following environment variables using Docker or the Launch Configuration in [Spring Tool Suite](https://spring.io/tools):
 
-* `INDEXING_ELASTIC_HOST`: This is the host for your Elasticsearch server
-* `INDEXING_ELASTIC_PORT`: This is the port for your Elasticsearch server
-* `INDEXING_ELASTIC_PROTOCOL`: Protocol for communicating with Elasticsearch, by default it's `http`
+- `INDEXING_ELASTIC_HOST`: This is the host for your Elasticsearch server
+- `INDEXING_ELASTIC_PORT`: This is the port for your Elasticsearch server
+- `INDEXING_ELASTIC_PROTOCOL`: Protocol for communicating with Elasticsearch, by default it's `http`
 
 ### Docker Compose
+
 This microservice is designed to be used with other microservices. Please look at the [docker-compose](./docker-compose.yml) file for more information.
 
-* `OBJECT_URL`: This is a configurable environment variable to point to where the Object Microservice is running.
+- `OBJECT_URL`: This is a configurable environment variable to point to where the Object Microservice is running.
 
 ### OAuth 2 Configuration
 
@@ -62,22 +66,23 @@ __Scopes__: This application uses the following scope: `indexing.*`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 
-* `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
-* `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
-* `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
-* `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
-* `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
+- `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
+- `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
+- `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
+- `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
+- `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
 
 ### Miscellaneous Configurations
 
 Here are other various configurations and their purposes:
 
-* `INDEXING_PORT`: This is a configurable port the application is set to run on
-* `INDEXING_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
-* `INDEXING_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
-* `INDEXING_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
+- `INDEXING_PORT`: This is a configurable port the application is set to run on
+- `INDEXING_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
+- `INDEXING_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
+- `INDEXING_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
   
 ## Public Domain
+
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
 the public domain within the United States, and copyright and related rights in
@@ -87,6 +92,7 @@ submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
 ## License
+
 The repository utilizes code licensed under the terms of the Apache Software
 License and therefore is licensed under ASL v2 or later.
 
@@ -103,8 +109,8 @@ program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
 
 The source code forked from other open source projects will inherit its license.
 
-
 ## Privacy
+
 This repository contains only non-sensitive, publicly available data and
 information. All material and community participation is covered by the
 Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
@@ -112,6 +118,7 @@ and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-con
 For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
 
 ## Contributing
+
 Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo)
 and submitting a pull request. (If you are new to GitHub, you might start with a
 [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
@@ -125,11 +132,13 @@ CDC including this GitHub page are subject to the [Presidential Records Act](htt
 and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
 ## Records
+
 This repository is not a source of government records, but is a copy to increase
 collaboration and collaborative potential. All government records will be
 published through the [CDC web site](http://www.cdc.gov).
 
 ## Notices
+
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
 for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
 [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.3.0

--- a/stack.yml
+++ b/stack.yml
@@ -1,0 +1,56 @@
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  fdns-ms-object:
+    image: cdcgov/fdns-ms-object
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+      - mongo
+    environment:
+      OBJECT_PORT: 8083
+      OBJECT_MONGO_HOST: mongo
+      OBJECT_MONGO_PORT: 27017
+      OBJECT_FLUENTD_HOST: fluentd
+      OBJECT_FLUENTD_PORT: 24224
+  elastic:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.0
+    ports:
+      - "9200:9200"
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+  fdns-ms-indexing:
+    image: cdcgov/fdns-ms-indexing
+    ports:
+      - "8084:8084"
+    depends_on:
+      - fluentd
+      - elastic
+      - fdns-ms-object
+    environment:
+      INDEXING_PORT: 8084
+      INDEXING_ELASTIC_HOST: elastic
+      INDEXING_ELASTIC_PORT: 9200
+      INDEXING_ELASTIC_PROTOCOL: http
+      INDEXING_FLUENTD_HOST: fluentd
+      INDEXING_FLUENTD_PORT: 24224
+      OBJECT_URL: http://fdns-ms-object:8083


### PR DESCRIPTION
This pull request updates the README with small fixes for markdown (lines after headers are suggested, etc.). 

This also adds a suggested documentation for Docker Hub and adds a `stack.yml` to be used with http://play-with-docker.com/