### PR TITLE
Trello 179: Updating http response codes in indexing controller and respective test cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cdc</groupId>
 	<artifactId>fdns-ms-indexing</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>FDNS Indexing Microservice</name>
@@ -119,7 +119,6 @@
 			<artifactId>rest</artifactId>
 			<version>5.5.3</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
@@ -131,7 +130,6 @@
 			<artifactId>log4j-core</artifactId>
 			<version>2.11.1</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.jacoco</groupId>
 			<artifactId>jacoco-maven-plugin</artifactId>
@@ -160,7 +158,7 @@
 		<dependency>
 			<groupId>gov.cdc</groupId>
 			<artifactId>fdns-java-sdk</artifactId>
-			<version>1.0.1</version>
+			<version>1.0.3</version>
 		</dependency>
 
 		<!-- dependency overrides from the dependency tree -->

--- a/src/main/java/gov/cdc/foundation/helper/MessageHelper.java
+++ b/src/main/java/gov/cdc/foundation/helper/MessageHelper.java
@@ -10,6 +10,8 @@ public class MessageHelper extends AbstractMessageHelper {
 	public static final String CONST_OBJECTTYPE = "objectType";
 	public static final String CONST_OBJECTID = "objectId";
 	public static final String CONST_CONFIG = "config";
+	public static final String CONST_TYPE = "type";
+	public static final String CONST_ROOT_CAUSE = "root_cause";
 
 	public static final String METHOD_INDEX = "index";
 	public static final String METHOD_INDEXOBJECT = "indexObject";
@@ -30,9 +32,15 @@ public class MessageHelper extends AbstractMessageHelper {
 	public static final String ERROR_NO_DATABASE = "The database has not been provided in the configuration file.";
 	public static final String ERROR_NO_COLLECTION = "The collection has not been provided in the configuration file.";
 	public static final String ERROR_NO_INDEX = "The index has not been provided in the configuration file.";
+	public static final String ERROR_INDEX_DOESNT_EXIST = "This index doesn't exist.";
+	public static final String ERROR_SCROLL_IDENTIFIER_DOESNT_EXIST = "This scroll identifier doesn't exist";
+	public static final String ERROR_INDEX_ALREADY_EXIST = "This index already exists.";
 	public static final String ERROR_NO_TYPE = "The type has not been provided in the configuration file.";
 	public static final String ERROR_NO_OBJECT = "The following object doesn't exist.";
 	public static final String ERROR_BULK_MAX = "The bulk indexing processs accepts a maximum of 100 ids.";
+
+	public static final String EXCEPTION_ILLEGAL_ARGUMENT = "illegal_argument_exception";
+	public static final String EXCEPTION_PARSE = "parse_exception";
 
 	private MessageHelper() {
 		throw new IllegalAccessError("Helper class");


### PR DESCRIPTION
Annotations added for indexing swagger page to display and describe error codes for each endpoint.

Indexing controller now properly returns 404, 413, 422, and 201 when applicable with respective message describing the reason for the error.
